### PR TITLE
html encode user name

### DIFF
--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -81,7 +81,7 @@ class main_listener implements EventSubscriberInterface
 		$text = $event['text'];
 		$text = preg_replace_callback('/(<MOD\s*mod=").*?(".*?\[\s*mod=\s*)(.*?)(\s*\]|\s*time=|\s*user_id=|\s*mode=)((?s).*?<\/MOD>)/i', function ($regex_a) 
 		{
-			$username_var = '{@mod_break_username@'.$regex_a[3].'@}';
+			$username_var = htmlentities('{@mod_break_username@'.$regex_a[3].'@}');
 			return $regex_a[1].$username_var.$regex_a[2].$regex_a[3].$regex_a[4].$regex_a[5];
 		}, $text);
 		$text = preg_replace_callback('/(<MOD\s*mod=")(.*?)(".*?\[\s*mod=\s*)(.*?)(\s*time=\s*)([0-9]*)(\s*user_id=\s*)([0-9]*)(\s*mode=\s*)([01])((?s).*?\].*?<\/MOD>)/i', function ($regex_a) 


### PR DESCRIPTION
A moderator put quotes around his name in the bbc code `[mod="name"]` resulting in faulty HTML and causing the mask values not to be replaced and even caused `500 Internal Server Error`. The entire thread on the forum could no longer be accessed.

The text behind mod= should not be blindly inserted into `<MOD mod="..."`.

Beside my fix to use htmlentities(), it is perhaps also wise to limit the user name to a certain max length before calling htmlentities().